### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ amalloy.ring-buffer> (peek (into (ring-buffer 3) '(a b c d e)))
 c
 ```
 
+## Installation
+
+See the [ring-buffer Clojars page](https://clojars.org/amalloy/ring-buffer) for Leiningen and Maven
+install snippets.
+
 ## License
 
 Copyright © 2012 Alan Malloy


### PR DESCRIPTION
Include Clojars link in README.

This is the most-weight way I can think of to include installation help and avoid having the current version number in the readme. 
