### PR TITLE
[Fix #10] - fixes Java11 ambiguous .toArray definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,35 @@ that's a tradeoff some may not be willing to make.
 
 ## Usage
 
-```clojure
-amalloy.ring-buffer> (into (ring-buffer 3) '(a b))
-(a b)
-amalloy.ring-buffer> (into (ring-buffer 3) '(a b c d e))
-(c d e)
-amalloy.ring-buffer> (pop (into (ring-buffer 3) '(a b c d e)))
-(d e)
-amalloy.ring-buffer> (peek (into (ring-buffer 3) '(a b c d e)))
-c
-```
+Add the dependency into your `project.clj`
 
-## Installation
+``` clojure
+[amalloy/ring-buffer "1.2.1"]
+```
+Latest version: [![Clojars Project](https://img.shields.io/clojars/v/amalloy/ring-buffer.svg)](https://clojars.org/amalloy/ring-buffer)
 
 See the [ring-buffer Clojars page](https://clojars.org/amalloy/ring-buffer) for Leiningen and Maven
 install snippets.
+
+Then require the namespace:
+
+```clojure
+(ns your.ns
+ (:require [amalloy.ring-buffer :refer :all]))
+```
+
+Finally add and remove items from the ring-buffer
+
+```clojure
+(into (ring-buffer 3) '(a b))
+;;=> (a b)
+(into (ring-buffer 3) '(a b c d e))
+;;=> (c d e)
+(pop (into (ring-buffer 3) '(a b c d e)))
+;;=> (d e)
+(peek (into (ring-buffer 3) '(a b c d e)))
+;;=> c
+```
 
 ## Development
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amalloy/ring-buffer "1.2.1"
+(defproject amalloy/ring-buffer "1.2.2"
   :description "Persistent bounded-size queue implementation in Clojure"
   :url "http://github.com/amalloy/ring-buffer"
   :license {:name "Eclipse Public License"

--- a/src/amalloy/ring_buffer.clj
+++ b/src/amalloy/ring_buffer.clj
@@ -71,7 +71,7 @@
     (.count this))
   (isEmpty [this]
     (empty? this))
-  (toArray [this dest]
+  (^objects toArray [this ^objects dest]
     (reduce (fn [idx item]
               (aset dest idx item)
               (inc idx))


### PR DESCRIPTION
Fixes issue #10. In Java11 due to the introduction of the new [toArray​(IntFunction<T[]> generator)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Collection.html#toArray(java.util.function.IntFunction))

```
openjdk version "11.0.1" 2018-10-16
OpenJDK Runtime Environment 18.9 (build 11.0.1+13)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.1+13, mixed mode)

$ lein do clean, check
Compiling namespace amalloy.ring-buffer
Exception in thread "main" java.lang.IllegalArgumentException: Must hint overloaded method: toArray, compiling:(amalloy/ring_buffer.clj:17:1)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6730)
	at clojure.lang.Compiler.analyze(Compiler.java:6524)
	at clojure.lang.Compiler.analyze(Compiler.java:6485)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:5861)
	at clojure.lang.Compiler$LetExpr$Parser.parse(Compiler.java:6179)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6723)
	at clojure.lang.Compiler.analyze(Compiler.java:6524)
	at clojure.lang.Compiler.analyze(Compiler.java:6485)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:5861)
	at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5296)
	at clojure.lang.Compiler$FnExpr.parse(Compiler.java:3925)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6721)
	at clojure.lang.Compiler.analyze(Compiler.java:6524)
	at clojure.lang.Compiler.eval(Compiler.java:6779)
	at clojure.lang.Compiler.load(Compiler.java:7227)
	at clojure.lang.RT.loadResourceScript(RT.java:371)
	at clojure.lang.RT.loadResourceScript(RT.java:362)
	at clojure.lang.RT.load(RT.java:446)
	at clojure.lang.RT.load(RT.java:412)
	at clojure.core$load$fn__5448.invoke(core.clj:5866)
	at clojure.core$load.doInvoke(core.clj:5865)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at user$eval5$fn__16.invoke(form-init5131200994711812227.clj:1)
	at user$eval5.invoke(form-init5131200994711812227.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:6782)
	at clojure.lang.Compiler.eval(Compiler.java:6772)
	at clojure.lang.Compiler.load(Compiler.java:7227)
	at clojure.lang.Compiler.loadFile(Compiler.java:7165)
	at clojure.main$load_script.invoke(main.clj:275)
	at clojure.main$init_opt.invoke(main.clj:280)
	at clojure.main$initialize.invoke(main.clj:308)
	at clojure.main$null_opt.invoke(main.clj:343)
	at clojure.main$main.doInvoke(main.clj:421)
	at clojure.lang.RestFn.invoke(RestFn.java:421)
	at clojure.lang.Var.invoke(Var.java:383)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.Var.applyTo(Var.java:700)
	at clojure.main.main(main.java:37)
Caused by: java.lang.IllegalArgumentException: Must hint overloaded method: toArray
	at clojure.lang.Compiler$NewInstanceMethod.parse(Compiler.java:8050)
	at clojure.lang.Compiler$NewInstanceExpr.build(Compiler.java:7642)
	at clojure.lang.Compiler$NewInstanceExpr$DeftypeParser.parse(Compiler.java:7523)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6723)
	... 37 more
```

This patch adds the right type hints.

In addition I've added a few more info in the README and bumped the version.
I'd appreciate if you can review/merge this PR and relase the jars into Clojars.
